### PR TITLE
Add ret_count while querying the grid3 nodes to get total counts in headers

### DIFF
--- a/server/controllers/directory.js
+++ b/server/controllers/directory.js
@@ -37,6 +37,7 @@ function getItemFromExplorer(type, gridVersion, network, size, page) {
           params: {
             size,
             page,
+            ret_count: true
           },
         })
         .then(res)


### PR DESCRIPTION
This will be required before releasing the gridproxy as the counts will be only returned if `ret_count=true` is passed as a query param.
- https://github.com/threefoldtech/tfgridclient_proxy/issues/127
